### PR TITLE
addMessage: if e.message is empty

### DIFF
--- a/system/RestHandler.cfc
+++ b/system/RestHandler.cfc
@@ -94,7 +94,7 @@ component extends="EventHandler" {
 			// Setup General Error Response
 			arguments.prc.response
 				.setError( true )
-				.addMessage( "General application error: #e.message#" )
+				.addMessage( "General application error: #Len(e.message) ? e.message : e.Detail#" )
 				.setStatusCode( arguments.event.STATUS.INTERNAL_ERROR )
 				.setStatusText( "General application error" );
 


### PR DESCRIPTION
PostgreSQL driver leaves empty the "message" field on Error.
This patch uses "Detail" field if "message" is empty.

https://imgur.com/a/9JSXLd8